### PR TITLE
Add the ability to load unsupported builtin modules

### DIFF
--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -186,9 +186,10 @@ module.exports = class ModuleDownloader {
             manifest.auth = manifest.auth || {};
 
             if (manifest.module_type === 'org.thingpedia.builtin') {
-                if (!this._builtins[id])
-                    throw new Error(`The device ${id} is not supported in this instance of ThingSystem`);
-                return new Modules['org.thingpedia.builtin'](id, manifest, this, this._builtins[id].module);
+                if (this._builtins[id])
+                    return new Modules['org.thingpedia.builtin'](id, manifest, this, this._builtins[id].module);
+                else
+                    return new Modules['org.thingpedia.builtin.unsupported'](id, manifest, this);
             }
 
             console.log('Loaded manifest for ' + id + ', module type: '+ manifest.module_type + ', version: ' + manifest.version);

--- a/lib/modules/index.js
+++ b/lib/modules/index.js
@@ -14,9 +14,11 @@ const V2 = require('./v2');
 const GenericRestModule = require('./generic');
 const RSSModule = require('./rss_factory');
 const BuiltinModule = require('./builtin');
+const UnsupportedBuiltinModule = require('./unsupported_builtin');
 
 module.exports = {
     'org.thingpedia.builtin': BuiltinModule,
+    'org.thingpedia.builtin.unsupported': UnsupportedBuiltinModule,
 
     'org.thingpedia.v2': V2,
     'org.thingpedia.rss': RSSModule,

--- a/lib/modules/unsupported_builtin.js
+++ b/lib/modules/unsupported_builtin.js
@@ -1,0 +1,84 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of ThingEngine
+//
+// Copyright 2017 The Board of Trustees of the Leland Stanford Junior University
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+//
+// See LICENSE for details
+"use strict";
+
+const Tp = require('thingpedia');
+const Utils = require('./utils');
+
+class UnsupportedError extends Error {
+    constructor() {
+        super(`This command is not available in this version of Almond`);
+        this.code = 'ENOSYS';
+    }
+}
+
+module.exports = class UnsupportedBuiltinModule {
+    constructor(id, manifest, loader) {
+        // version does not matter for builtin modules
+        manifest.version = 0;
+        this._id = id;
+        this._manifest = manifest;
+
+        this._loaded = class UnsupportedDevice extends Tp.BaseDevice {
+            constructor(engine, state) {
+                super(engine, state);
+
+                this.uniqueId = this.kind;
+                this.name = Utils.formatString(this.constructor.metadata.name, this.state);
+                if (this.constructor.metadata.description)
+                    this.description = Utils.formatString(this.constructor.metadata.description, this.state);
+            }
+
+            checkAvailable() {
+                return Tp.BaseDevice.Availability.OWNER_UNAVAILABLE;
+            }
+        };
+
+        for (let action in manifest.actions) {
+            this._loaded.prototype['do_' + action] = function(params) {
+                throw new UnsupportedError();
+            };
+        }
+        for (let query in manifest.queries) {
+            this._loaded.prototype['get_' + query] = function(params, filter, count) {
+                throw new UnsupportedError();
+            };
+            this._loaded.prototype['subscribe_' + query] = function(params, state, filter) {
+                throw new UnsupportedError();
+            };
+            this._loaded.prototype['history_' + query] = function(params, base, delta, filters) {
+                return null; // no history
+            };
+            this._loaded.prototype['sequence_' + query] = function(params, base, limit, filters) {
+                return null; // no sequence history
+            };
+        }
+
+        this._loaded.metadata = manifest;
+    }
+
+    get id() {
+        return this._id;
+    }
+    get manifest() {
+        return this._manifest;
+    }
+    get version() {
+        return this._manifest.version;
+    }
+
+    clearCache() {
+        // nothing to do here
+    }
+
+    getDeviceFactory() {
+        return Promise.resolve(this._loaded);
+    }
+};

--- a/test/device-classes/org.thingpedia.builtin.test.invalid.tt
+++ b/test/device-classes/org.thingpedia.builtin.test.invalid.tt
@@ -1,10 +1,11 @@
 class @org.thingpedia.builtin.test.invalid
 #_[name="Invalid Builtin"]
 #_[description="Invalid Builtin Description"]
+#[version=0]
 {
 	import loader from @org.thingpedia.builtin();
 	import config from @org.thingpedia.config.builtin();
 
 	monitorable query foo(out something : String)
 	#[poll_interval=1ms];
-} 
+}

--- a/test/device-classes/org.thingpedia.builtin.test.invalid.tt
+++ b/test/device-classes/org.thingpedia.builtin.test.invalid.tt
@@ -1,0 +1,10 @@
+class @org.thingpedia.builtin.test.invalid
+#_[name="Invalid Builtin"]
+#_[description="Invalid Builtin Description"]
+{
+	import loader from @org.thingpedia.builtin();
+	import config from @org.thingpedia.config.builtin();
+
+	monitorable query foo(out something : String)
+	#[poll_interval=1ms];
+} 

--- a/test/test_api.js
+++ b/test/test_api.js
@@ -36,6 +36,7 @@ async function testQuery() {
         { name: 'org.httpbin.basicauth', version: 1 },
         { name: 'org.httpbin.broken', version: 1 },
         { name: 'org.httpbin.oauth', version: 1 },
+        { name: 'org.thingpedia.builtin.test.invalid', version: 0 },
         { name: 'org.thingpedia.test.broken', version: 1 },
         { name: 'org.thingpedia.test.broken.noaction', version: 1 },
         { name: 'org.thingpedia.test.broken.noquery', version: 1 },


### PR DESCRIPTION
We want to remove platform builtin modules from thingengine-core,
but due to cloud sync we still need to load _something_ on other
platforms. We cannot load the correct device, but we can load
a dummy device that exposes the same interface and refuses to do
anything.