### PR TITLE
downloader: expose thingtalk module

### DIFF
--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -49,6 +49,13 @@ module.exports = class ModuleDownloader {
                 if (e.code !== 'EEXIST')
                     throw e;
             }
+            try {
+                fs.symlinkSync(path.dirname(require.resolve('thingtalk')),
+                               this._cacheDir + '/node_modules/thingtalk');
+            } catch(e) {
+                if (e.code !== 'EEXIST')
+                    throw e;
+            }
         }
     }
 


### PR DESCRIPTION
Allow requiring "thingtalk" from thingpedia devices, by symlinking
to the same version used by Almond.

This is useful to access experimental or undocumented features,
with the knowledge that they might change at any point, and the
device might break.