### PR TITLE
ModuleDownloader: inject the class earlier

### DIFF
--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -165,7 +165,9 @@ module.exports = class ModuleDownloader {
         const parsed = await ThingTalk.Grammar.parseAndTypecheck(classCode, this._schemas);
 
         assert(parsed.isMeta && parsed.classes.length === 1);
-        return parsed.classes[0];
+        const classdef = parsed.classes[0];
+        this._schemas.injectClass(classdef);
+        return classdef;
     }
 
     injectModule(id, module) {
@@ -186,7 +188,6 @@ module.exports = class ModuleDownloader {
 
             console.log('Loaded class definition for ' + id + ', module type: '+ module + ', version: ' + classdef.annotations.version.toJS());
 
-            this._schemas.injectClass(classdef);
             return new (Modules[module])(id, classdef, this);
         } catch(e) {
             // on error, propagate error but don't cache it (so the next time we'll try again)


### PR DESCRIPTION
Builtin modules have an early return that would cause us to skip
class injection, which is especially bad for builtins as they
are sensitive to version skew. Also make sure that the class
is injected for subdevices, which call loadClass and not getModule